### PR TITLE
add USB keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 - [`Sentry Safe` Plugin that can open any Sentry Safe and Master Lock electronic safe without entering pin code.](https://github.com/H4ckd4ddy/flipperzero-sentry-safe-plugin)
 - [`Dec/Hex Converter` Small "real time" decimal/hexadecimal converter.](https://github.com/theisolinearchip/flipperzero_stuff/tree/main/applications/dec_hex_converter)
 - [`MultiConverter` Multi-unit converter that can be easily expanded with new units and conversion methods.](https://github.com/theisolinearchip/flipperzero_stuff/tree/main/applications/multi_converter)
+- [`USB Keyboard` A refactor of the BT remote to work over USB. Allows the flipper to act as an USB HID keyboard.](https://github.com/huuck/FlipperZeroUSBKeyboard)
 
 ## Firmwares & Tweaks
 


### PR DESCRIPTION
Adding link to sdcard app for USB HID keyboard. It's just a simple rewrite of the BT remote app to connect inject keys via USB.