### PR TITLE
Add flipper2mct

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 - [`fzfs` Flipper Zero filesystem driver.](https://github.com/dakhnod/fzfs)
 - [`Pagger` Sub-GHz generators for restaurants/kiosks paging systems.](https://meoker.github.io/pagger/)
 - [`FBT-AARCH64` A script that sets up FBT's toolchain on ARM devices.](https://github.com/qqmajikpp/FBT-AARCH64)
+- [`flipper2mct` A script to convert Flipper NFC files to Mifare Classic Tools format for MC 1k & 4k.](https://gist.github.com/ardubev16/339ee55e0e610e9241dd236c11ac3c3d)
 
 ## Notes & References
 - [`Official battery self-repair guide` How to troubleshoot battery issues.](https://cdn.flipperzero.one/self-repair-guide.pdf)


### PR DESCRIPTION
Convert Flipper Zero Mifare Classic 1k & 4k dumps to MCT (Mifare Classic Tools). Fixed version (for 4k) of https://github.com/whyn0/FlipperNFC2MCT