### PR TITLE
fix: Update `Unleashed` description, remove outdated versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,14 +225,14 @@
 
 ### *Custom firmware (cfw)*
 
+- [`Unleashed` Unlocked most stable custom firmware focused on new features and improvements of original firmware components, keeping compatibility with original firmware API and **Apps**.](https://github.com/DarkFlippers/unleashed-firmware)
 - [`Momentum` Feature-rich, stable and customizable Flipper firmware: a direct continuation of the Xtreme firmware.](https://github.com/Next-Flip/Momentum-Firmware)
-- [`Xtreme` Official fork with cleaned up codebase, more module extensions and custom assets.](https://github.com/ClaraCrazy/Flipper-Xtreme)
-- [`Unleashed` Unlocked firmware with rolling codes support & community plugins, stable tweaks, and games.](https://github.com/DarkFlippers/unleashed-firmware)
 - [`RogueMaster` Fork of Unleashed firmware with custom graphics, experimental tweaks, community plugins and games.](https://github.com/RogueMaster/flipperzero-firmware-wPlugins)
-- [`Dexv` Xtreme fork; The "Will it blend?" of custom firmwares.](https://github.com/DXVVAY/Dexvmaster0)
 
 ### *Outdated/Unmaintained firmware*
 
+- [`Xtreme` Official fork with cleaned up codebase, more module extensions and custom assets. Now gone to the public archive.](https://github.com/ClaraCrazy/Flipper-Xtreme)
+- [`Dexv` Xtreme fork; The "Will it blend?" of custom firmwares.](https://github.com/DXVVAY/Dexvmaster0)
 - [`SquachWare` Fork of official firmware which adds custom graphics, community applications & files.](https://github.com/skizzophrenic/SquachWare-CFW)
 - [`Wetox` Very similar to the official branch, with a few small tweaks.](https://github.com/wetox-team/flipperzero-firmware)
 - [`Muddled Forks` Less-active firmware modifications.](https://github.com/MuddledBox/flipperzero-firmware/tree/muddled_dev)


### PR DESCRIPTION
# Description

People still install outdated versions of other firmware, and then come to the **Unleashed** chat asking for help.

# What is changed

- Outdated versions have been moved to the appropriate section.
- Updated the description of Unleashed in accordance with the main page of the project
- Changed the sorting
