### PR TITLE
Add PocketLab to Utility/Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@
 - [`MultiConverter` Multi-unit converter that can be easily expanded with new units and conversion methods.](https://github.com/theisolinearchip/flipperzero_stuff/tree/main/applications/multi_converter)
 - [`bpm-tapper` Tap along to a song to measure beats per minute.](https://github.com/panki27/bpm-tapper)
 - [`Flipp Pomodoro` Pomodoro Timer Tool for productivity.](https://github.com/Th3Un1q3/flipp_pomodoro)
+- [`PocketLab` Gamified, on-device learning: short interactive labs that teach your Flipper's own features, with XP, levels and badges.](https://github.com/PerfectoWeb/flipper-pocketlab)
 
 
 ## Firmwares & Tweaks


### PR DESCRIPTION
Adds PocketLab to Applications & Plugins -> Utility/Other.

PocketLab is a gamified, on-device learning app for Flipper Zero: short
interactive labs that teach the device's own features, with randomized quizzes
and XP/levels/badges. Open source (MIT), builds on the official firmware, and
submitted to the official app catalog.

Entry follows the existing format of the section.